### PR TITLE
Possibility to use different SPI devs (SPI1, SPI2)

### DIFF
--- a/src/SX126XLT.cpp
+++ b/src/SX126XLT.cpp
@@ -31,9 +31,16 @@ See LICENSE.TXT file included in the library
 */
 
 SX126XLT::SX126XLT()
+    : _spi(SPI)
 {
   //Anything you need when instantiating your object goes here
 }
+
+void SX126XLT::setSpi(SPIClass& spi)
+{
+    _spi = spi;
+}
+
 
 /* Formats for :begin
   original > begin(int8_t pinNSS, int8_t pinNRESET, int8_t pinRFBUSY, int8_t pinDIO1, int8_t pinDIO2, int8_t pinDIO3, int8_t pinSW, uint8_t device);
@@ -426,20 +433,20 @@ void SX126XLT::writeCommand(uint8_t Opcode, uint8_t *buffer, uint16_t size)
   checkBusy();
 
 #ifdef USE_SPI_TRANSACTION     //to use SPI_TRANSACTION enable define at beginning of CPP file 
-  SPI.beginTransaction(SPISettings(LTspeedMaximum, LTdataOrder, LTdataMode));
+  _spi.beginTransaction(SPISettings(LTspeedMaximum, LTdataOrder, LTdataMode));
 #endif
 
   digitalWrite(_NSS, LOW);
-  SPI.transfer(Opcode);
+  _spi.transfer(Opcode);
 
   for (index = 0; index < size; index++)
   {
-    SPI.transfer(buffer[index]);
+    _spi.transfer(buffer[index]);
   }
   digitalWrite(_NSS, HIGH);
 
 #ifdef USE_SPI_TRANSACTION
-  SPI.endTransaction();
+  _spi.endTransaction();
 #endif
 
   if (Opcode != RADIO_SET_SLEEP)
@@ -459,22 +466,22 @@ void SX126XLT::readCommand(uint8_t Opcode, uint8_t *buffer, uint16_t size)
   checkBusy();
 
 #ifdef USE_SPI_TRANSACTION     //to use SPI_TRANSACTION enable define at beginning of CPP file 
-  SPI.beginTransaction(SPISettings(LTspeedMaximum, LTdataOrder, LTdataMode));
+  _spi.beginTransaction(SPISettings(LTspeedMaximum, LTdataOrder, LTdataMode));
 #endif
 
   digitalWrite(_NSS, LOW);
-  SPI.transfer(Opcode);
-  SPI.transfer(0xFF);
+  _spi.transfer(Opcode);
+  _spi.transfer(0xFF);
 
   for ( i = 0; i < size; i++ )
   {
 
-    *(buffer + i) = SPI.transfer(0xFF);
+    *(buffer + i) = _spi.transfer(0xFF);
   }
   digitalWrite(_NSS, HIGH);
 
 #ifdef USE_SPI_TRANSACTION
-  SPI.endTransaction();
+  _spi.endTransaction();
 #endif
 
 }
@@ -493,23 +500,23 @@ void SX126XLT::writeRegisters(uint16_t address, uint8_t *buffer, uint16_t size)
   checkBusy();
 
 #ifdef USE_SPI_TRANSACTION     //to use SPI_TRANSACTION enable define at beginning of CPP file 
-  SPI.beginTransaction(SPISettings(LTspeedMaximum, LTdataOrder, LTdataMode));
+  _spi.beginTransaction(SPISettings(LTspeedMaximum, LTdataOrder, LTdataMode));
 #endif
 
   digitalWrite(_NSS, LOW);
-  SPI.transfer(RADIO_WRITE_REGISTER);
-  SPI.transfer(addr_h);   //MSB
-  SPI.transfer(addr_l);   //LSB
+  _spi.transfer(RADIO_WRITE_REGISTER);
+  _spi.transfer(addr_h);   //MSB
+  _spi.transfer(addr_l);   //LSB
 
   for (i = 0; i < size; i++)
   {
-    SPI.transfer(buffer[i]);
+    _spi.transfer(buffer[i]);
   }
 
   digitalWrite(_NSS, HIGH);
 
 #ifdef USE_SPI_TRANSACTION
-  SPI.endTransaction();
+  _spi.endTransaction();
 #endif
 }
 
@@ -537,23 +544,23 @@ void SX126XLT::readRegisters(uint16_t address, uint8_t *buffer, uint16_t size)
   checkBusy();
 
 #ifdef USE_SPI_TRANSACTION     //to use SPI_TRANSACTION enable define at beginning of CPP file 
-  SPI.beginTransaction(SPISettings(LTspeedMaximum, LTdataOrder, LTdataMode));
+  _spi.beginTransaction(SPISettings(LTspeedMaximum, LTdataOrder, LTdataMode));
 #endif
 
   digitalWrite(_NSS, LOW);
-  SPI.transfer(RADIO_READ_REGISTER);
-  SPI.transfer(addr_h);               //MSB
-  SPI.transfer(addr_l);               //LSB
-  SPI.transfer(0xFF);
+  _spi.transfer(RADIO_READ_REGISTER);
+  _spi.transfer(addr_h);               //MSB
+  _spi.transfer(addr_l);               //LSB
+  _spi.transfer(0xFF);
   for (index = 0; index < size; index++)
   {
-    *(buffer + index) = SPI.transfer(0xFF);
+    *(buffer + index) = _spi.transfer(0xFF);
   }
 
   digitalWrite(_NSS, HIGH);
 
 #ifdef USE_SPI_TRANSACTION
-  SPI.endTransaction();
+  _spi.endTransaction();
 #endif
 
 }
@@ -644,16 +651,16 @@ void SX126XLT::setMode(uint8_t modeconfig)
   checkBusy();
 
 #ifdef USE_SPI_TRANSACTION     //to use SPI_TRANSACTION enable define at beginning of CPP file 
-  SPI.beginTransaction(SPISettings(LTspeedMaximum, LTdataOrder, LTdataMode));
+  _spi.beginTransaction(SPISettings(LTspeedMaximum, LTdataOrder, LTdataMode));
 #endif
 
   digitalWrite(_NSS, LOW);
-  SPI.transfer(RADIO_SET_STANDBY);
-  SPI.transfer(modeconfig);
+  _spi.transfer(RADIO_SET_STANDBY);
+  _spi.transfer(modeconfig);
   digitalWrite(_NSS, HIGH);
 
 #ifdef USE_SPI_TRANSACTION
-  SPI.endTransaction();
+  _spi.endTransaction();
 #endif
 
   _OperatingMode = modeconfig;
@@ -1328,23 +1335,23 @@ uint8_t SX126XLT::transmit(uint8_t *txbuffer, uint8_t size, uint32_t txtimeout, 
   checkBusy();
 
 #ifdef USE_SPI_TRANSACTION     //to use SPI_TRANSACTION enable define at beginning of CPP file 
-  SPI.beginTransaction(SPISettings(LTspeedMaximum, LTdataOrder, LTdataMode));
+  _spi.beginTransaction(SPISettings(LTspeedMaximum, LTdataOrder, LTdataMode));
 #endif
 
   digitalWrite(_NSS, LOW);
-  SPI.transfer(RADIO_WRITE_BUFFER);
-  SPI.transfer(0);
+  _spi.transfer(RADIO_WRITE_BUFFER);
+  _spi.transfer(0);
 
   for (index = 0; index < size; index++)
   {
     bufferdata = txbuffer[index];
-    SPI.transfer(bufferdata);
+    _spi.transfer(bufferdata);
   }
 
   digitalWrite(_NSS, HIGH);
 
 #ifdef USE_SPI_TRANSACTION
-  SPI.endTransaction();
+  _spi.endTransaction();
 #endif
 
   _TXPacketL = size;
@@ -1664,24 +1671,24 @@ uint8_t SX126XLT::receive(uint8_t *rxbuffer, uint8_t size, uint32_t rxtimeout, u
   checkBusy();
   
 #ifdef USE_SPI_TRANSACTION           //to use SPI_TRANSACTION enable define at beginning of CPP file 
-  SPI.beginTransaction(SPISettings(LTspeedMaximum, LTdataOrder, LTdataMode));
+  _spi.beginTransaction(SPISettings(LTspeedMaximum, LTdataOrder, LTdataMode));
 #endif
 
   digitalWrite(_NSS, LOW);             //start the burst read
-  SPI.transfer(RADIO_READ_BUFFER);
-  SPI.transfer(RXstart);
-  SPI.transfer(0xFF);
+  _spi.transfer(RADIO_READ_BUFFER);
+  _spi.transfer(RXstart);
+  _spi.transfer(0xFF);
 
   for (index = RXstart; index < RXend; index++)
   {
-    regdata = SPI.transfer(0);
+    regdata = _spi.transfer(0);
     rxbuffer[index] = regdata;
   }
 
   digitalWrite(_NSS, HIGH);
 
 #ifdef USE_SPI_TRANSACTION
-  SPI.endTransaction();
+  _spi.endTransaction();
 #endif
 
   return _RXPacketL;                     //so we can check for packet having enough buffer space
@@ -1781,12 +1788,12 @@ void SX126XLT::startWriteSXBuffer(uint8_t ptr)
   checkBusy();
   
   #ifdef USE_SPI_TRANSACTION     //to use SPI_TRANSACTION enable define at beginning of CPP file 
-  SPI.beginTransaction(SPISettings(LTspeedMaximum, LTdataOrder, LTdataMode));
+  _spi.beginTransaction(SPISettings(LTspeedMaximum, LTdataOrder, LTdataMode));
 #endif
   
   digitalWrite(_NSS, LOW);
-  SPI.transfer(RADIO_WRITE_BUFFER);
-  SPI.transfer(ptr);
+  _spi.transfer(RADIO_WRITE_BUFFER);
+  _spi.transfer(ptr);
   //SPI interface ready for byte to write to buffer
 }
 
@@ -1800,7 +1807,7 @@ uint8_t  SX126XLT::endWriteSXBuffer()
   digitalWrite(_NSS, HIGH);
   
   #ifdef USE_SPI_TRANSACTION
-  SPI.endTransaction();
+  _spi.endTransaction();
 #endif
 
   return _TXPacketL;
@@ -1819,15 +1826,15 @@ void SX126XLT::startReadSXBuffer(uint8_t ptr)
   checkBusy();
   
   #ifdef USE_SPI_TRANSACTION             //to use SPI_TRANSACTION enable define at beginning of CPP file 
-  SPI.beginTransaction(SPISettings(LTspeedMaximum, LTdataOrder, LTdataMode));
+  _spi.beginTransaction(SPISettings(LTspeedMaximum, LTdataOrder, LTdataMode));
   #endif
 
   digitalWrite(_NSS, LOW);               //start the burst read
-  SPI.transfer(RADIO_READ_BUFFER);
-  SPI.transfer(ptr);
-  SPI.transfer(0xFF);
+  _spi.transfer(RADIO_READ_BUFFER);
+  _spi.transfer(ptr);
+  _spi.transfer(0xFF);
 
-  //next line would be data = SPI.transfer(0);
+  //next line would be data = _spi.transfer(0);
   //SPI interface ready for byte to read from
 }
 
@@ -1841,7 +1848,7 @@ uint8_t SX126XLT::endReadSXBuffer()
   digitalWrite(_NSS, HIGH);
   
   #ifdef USE_SPI_TRANSACTION
-  SPI.endTransaction();
+  _spi.endTransaction();
 #endif
   
   return _RXPacketL;
@@ -1854,7 +1861,7 @@ void SX126XLT::writeUint8(uint8_t x)
   Serial.println(F("writeUint8()"));
 #endif
 
-  SPI.transfer(x);
+  _spi.transfer(x);
 
   _TXPacketL++;                        //increment count of bytes written
 }
@@ -1866,7 +1873,7 @@ uint8_t SX126XLT::readUint8()
 #endif
   byte x;
 
-  x = SPI.transfer(0);
+  x = _spi.transfer(0);
 
   _RXPacketL++;                        //increment count of bytes read
   return (x);
@@ -1879,7 +1886,7 @@ void SX126XLT::writeInt8(int8_t x)
   Serial.println(F("writeInt8()"));
 #endif
 
-  SPI.transfer(x);
+  _spi.transfer(x);
 
   _TXPacketL++;                        //increment count of bytes written
 }
@@ -1892,7 +1899,7 @@ int8_t SX126XLT::readInt8()
 #endif
   int8_t x;
 
-  x = SPI.transfer(0);
+  x = _spi.transfer(0);
 
   _RXPacketL++;                        //increment count of bytes read
   return (x);
@@ -1905,8 +1912,8 @@ void SX126XLT::writeInt16(int16_t x)
   Serial.println(F("writeInt16()"));
 #endif
 
-  SPI.transfer(lowByte(x));
-  SPI.transfer(highByte(x));
+  _spi.transfer(lowByte(x));
+  _spi.transfer(highByte(x));
 
   _TXPacketL = _TXPacketL + 2;         //increment count of bytes written
 }
@@ -1919,8 +1926,8 @@ int16_t SX126XLT::readInt16()
 #endif
   byte lowbyte, highbyte;
 
-  lowbyte = SPI.transfer(0);
-  highbyte = SPI.transfer(0);
+  lowbyte = _spi.transfer(0);
+  highbyte = _spi.transfer(0);
 
   _RXPacketL = _RXPacketL + 2;         //increment count of bytes read
   return ((highbyte << 8) + lowbyte);
@@ -1933,8 +1940,8 @@ void SX126XLT::writeUint16(uint16_t x)
   Serial.println(F("writeUint16()"));
 #endif
 
-  SPI.transfer(lowByte(x));
-  SPI.transfer(highByte(x));
+  _spi.transfer(lowByte(x));
+  _spi.transfer(highByte(x));
 
   _TXPacketL = _TXPacketL + 2;         //increment count of bytes written
 }
@@ -1947,8 +1954,8 @@ uint16_t SX126XLT::readUint16()
 #endif
   byte lowbyte, highbyte;
 
-  lowbyte = SPI.transfer(0);
-  highbyte = SPI.transfer(0);
+  lowbyte = _spi.transfer(0);
+  highbyte = _spi.transfer(0);
 
   _RXPacketL = _RXPacketL + 2;         //increment count of bytes read
   return ((highbyte << 8) + lowbyte);
@@ -1973,7 +1980,7 @@ void SX126XLT::writeInt32(int32_t x)
   for (i = 0; i < 4; i++)
   {
     j = data.b[i];
-    SPI.transfer(j);
+    _spi.transfer(j);
   }
 
   _TXPacketL = _TXPacketL + 4;         //increment count of bytes written
@@ -1996,7 +2003,7 @@ int32_t SX126XLT::readInt32()
 
   for (i = 0; i < 4; i++)
   {
-    j = SPI.transfer(0);
+    j = _spi.transfer(0);
     readdata.b[i] = j;
   }
   _RXPacketL = _RXPacketL + 4;         //increment count of bytes read
@@ -2022,7 +2029,7 @@ void SX126XLT::writeUint32(uint32_t x)
   for (i = 0; i < 4; i++)
   {
     j = data.b[i];
-    SPI.transfer(j);
+    _spi.transfer(j);
   }
 
   _TXPacketL = _TXPacketL + 4;         //increment count of bytes written
@@ -2045,7 +2052,7 @@ uint32_t SX126XLT::readUint32()
 
   for (i = 0; i < 4; i++)
   {
-    j = SPI.transfer(0);
+    j = _spi.transfer(0);
     readdata.b[i] = j;
   }
   _RXPacketL = _RXPacketL + 4;         //increment count of bytes read
@@ -2071,7 +2078,7 @@ void SX126XLT::writeFloat(float x)
   for (i = 0; i < 4; i++)
   {
     j = data.b[i];
-    SPI.transfer(j);
+    _spi.transfer(j);
   }
 
   _TXPacketL = _TXPacketL + 4;         //increment count of bytes written
@@ -2094,7 +2101,7 @@ float SX126XLT::readFloat()
 
   for (i = 0; i < 4; i++)
   {
-    j = SPI.transfer(0);
+    j = _spi.transfer(0);
     readdata.b[i] = j;
   }
   _RXPacketL = _RXPacketL + 4;         //increment count of bytes read
@@ -2149,10 +2156,10 @@ void SX126XLT::writeBuffer(uint8_t *txbuffer, uint8_t size)
   for (index = 0; index < size; index++)
   {
     regdata = txbuffer[index];
-    SPI.transfer(regdata);
+    _spi.transfer(regdata);
   }
 
-  SPI.transfer(0);                     //this ensures last byte of buffer written really is a null (0)
+  _spi.transfer(0);                     //this ensures last byte of buffer written really is a null (0)
 
 }
 
@@ -2206,7 +2213,7 @@ uint8_t SX126XLT::readBuffer(uint8_t *rxbuffer)
 
   do                                     //need to find the size of the buffer first
   {
-    regdata = SPI.transfer(0);
+    regdata = _spi.transfer(0);
     rxbuffer[index] = regdata;           //fill the buffer.
     index++;
   } while (regdata != 0);                //keep reading until we have reached the null (0) at the buffer end
@@ -2263,16 +2270,16 @@ void SX126XLT::setSleep(uint8_t sleepconfig)
   checkBusy();
   
   #ifdef USE_SPI_TRANSACTION          //to use SPI_TRANSACTION enable define at beginning of CPP file 
-  SPI.beginTransaction(SPISettings(LTspeedMaximum, LTdataOrder, LTdataMode));
+  _spi.beginTransaction(SPISettings(LTspeedMaximum, LTdataOrder, LTdataMode));
 #endif
   
   digitalWrite(_NSS, LOW);
-  SPI.transfer(RADIO_SET_SLEEP);
-  SPI.transfer(sleepconfig);
+  _spi.transfer(RADIO_SET_SLEEP);
+  _spi.transfer(sleepconfig);
   digitalWrite(_NSS, HIGH);
   
   #ifdef USE_SPI_TRANSACTION
-  SPI.endTransaction();
+  _spi.endTransaction();
   #endif
   
   if (_SW >= 0)
@@ -2409,28 +2416,28 @@ void SX126XLT::toneFM(uint16_t frequency, uint32_t length, uint32_t deviation, f
   setTXDirect();
   
   #ifdef USE_SPI_TRANSACTION     //to use SPI_TRANSACTION enable define at beginning of CPP file 
-  SPI.beginTransaction(SPISettings(LTspeedMaximum, LTdataOrder, LTdataMode));
+  _spi.beginTransaction(SPISettings(LTspeedMaximum, LTdataOrder, LTdataMode));
   #endif
     
   for (index = 1; index <= loopcount; index++)
 {
   digitalWrite(_NSS, LOW);
-  SPI.transfer(RADIO_SET_RFFREQUENCY); 
-  SPI.transfer(HighShiftH);
-  SPI.transfer(HighShiftMH);
-  SPI.transfer(HighShiftML);
-  SPI.transfer(HighShiftL);
+  _spi.transfer(RADIO_SET_RFFREQUENCY); 
+  _spi.transfer(HighShiftH);
+  _spi.transfer(HighShiftMH);
+  _spi.transfer(HighShiftML);
+  _spi.transfer(HighShiftL);
   digitalWrite(_NSS, HIGH);
   
   
   delayMicroseconds(ToneDelayus);
   
   digitalWrite(_NSS, LOW);
-  SPI.transfer(RADIO_SET_RFFREQUENCY); 
-  SPI.transfer(LowShiftH);
-  SPI.transfer(LowShiftMH);
-  SPI.transfer(LowShiftML);
-  SPI.transfer(LowShiftL);
+  _spi.transfer(RADIO_SET_RFFREQUENCY); 
+  _spi.transfer(LowShiftH);
+  _spi.transfer(LowShiftMH);
+  _spi.transfer(LowShiftML);
+  _spi.transfer(LowShiftL);
   digitalWrite(_NSS, HIGH);
 
   delayMicroseconds(ToneDelayus);
@@ -2438,15 +2445,15 @@ void SX126XLT::toneFM(uint16_t frequency, uint32_t length, uint32_t deviation, f
   
   //now set the frequency registers back to centre
   digitalWrite(_NSS, LOW);                  //set NSS low
-  SPI.transfer(0x86);                       //address for write to REG_FRMSB
-  SPI.transfer(freqregH);
-  SPI.transfer(freqregMH);
-  SPI.transfer(freqregML);
-  SPI.transfer(freqregL);
+  _spi.transfer(0x86);                       //address for write to REG_FRMSB
+  _spi.transfer(freqregH);
+  _spi.transfer(freqregMH);
+  _spi.transfer(freqregML);
+  _spi.transfer(freqregL);
   digitalWrite(_NSS, HIGH);                 //set NSS high
   
   #ifdef USE_SPI_TRANSACTION
-  SPI.endTransaction();
+  _spi.endTransaction();
   #endif
   
   setMode(MODE_STDBY_RC);                   //turns off carrier
@@ -2463,18 +2470,18 @@ uint8_t SX126XLT::getByteSXBuffer(uint8_t addr)
   setMode(MODE_STDBY_RC);                     //this is needed to ensure we can read from buffer OK.
 
 #ifdef USE_SPI_TRANSACTION                    //to use SPI_TRANSACTION enable define at beginning of CPP file 
-  SPI.beginTransaction(SPISettings(LTspeedMaximum, LTdataOrder, LTdataMode));
+  _spi.beginTransaction(SPISettings(LTspeedMaximum, LTdataOrder, LTdataMode));
 #endif
 
   digitalWrite(_NSS, LOW);             //start the burst read
-  SPI.transfer(RADIO_READ_BUFFER);
-  SPI.transfer(addr);
-  SPI.transfer(0xFF);
-  regdata = SPI.transfer(0);
+  _spi.transfer(RADIO_READ_BUFFER);
+  _spi.transfer(addr);
+  _spi.transfer(0xFF);
+  regdata = _spi.transfer(0);
   digitalWrite(_NSS, HIGH);
 
 #ifdef USE_SPI_TRANSACTION
-  SPI.endTransaction();
+  _spi.endTransaction();
 #endif
 
   return regdata;
@@ -2492,17 +2499,17 @@ void SX126XLT::printSXBufferHEX(uint8_t start, uint8_t end)
   setMode(MODE_STDBY_RC);
 
 #ifdef USE_SPI_TRANSACTION     //to use SPI_TRANSACTION enable define at beginning of CPP file 
-  SPI.beginTransaction(SPISettings(LTspeedMaximum, LTdataOrder, LTdataMode));
+  _spi.beginTransaction(SPISettings(LTspeedMaximum, LTdataOrder, LTdataMode));
 #endif
 
   digitalWrite(_NSS, LOW);                       //start the burst read
-  SPI.transfer(RADIO_READ_BUFFER);
-  SPI.transfer(start);
-  SPI.transfer(0xFF);
+  _spi.transfer(RADIO_READ_BUFFER);
+  _spi.transfer(start);
+  _spi.transfer(0xFF);
 
   for (index = start; index <= end; index++)
   {
-    regdata = SPI.transfer(0);
+    regdata = _spi.transfer(0);
     printHEXByte(regdata);
     Serial.print(F(" "));
 
@@ -2510,7 +2517,7 @@ void SX126XLT::printSXBufferHEX(uint8_t start, uint8_t end)
   digitalWrite(_NSS, HIGH);
   
   #ifdef USE_SPI_TRANSACTION
-  SPI.endTransaction();
+  _spi.endTransaction();
 #endif
 
 }
@@ -2617,28 +2624,28 @@ uint8_t SX126XLT::transmitAddressed(uint8_t *txbuffer, uint8_t size, char txpack
   checkBusy();
   
   #ifdef USE_SPI_TRANSACTION     //to use SPI_TRANSACTION enable define at beginning of CPP file 
-  SPI.beginTransaction(SPISettings(LTspeedMaximum, LTdataOrder, LTdataMode));
+  _spi.beginTransaction(SPISettings(LTspeedMaximum, LTdataOrder, LTdataMode));
 #endif
   
   digitalWrite(_NSS, LOW);
-  SPI.transfer(RADIO_WRITE_BUFFER);
-  SPI.transfer(0);
+  _spi.transfer(RADIO_WRITE_BUFFER);
+  _spi.transfer(0);
   
-  SPI.transfer(txpackettype);                     //Write the packet type
-  SPI.transfer(txdestination);                    //Destination node
-  SPI.transfer(txsource);                         //Source node
+  _spi.transfer(txpackettype);                     //Write the packet type
+  _spi.transfer(txdestination);                    //Destination node
+  _spi.transfer(txsource);                         //Source node
   _TXPacketL = 3 + size;                          //we have added 3 header bytes to size
 
   for (index = 0; index < size; index++)
   {
     bufferdata = txbuffer[index];
-    SPI.transfer(bufferdata);
+    _spi.transfer(bufferdata);
   }
 
   digitalWrite(_NSS, HIGH);
   
   #ifdef USE_SPI_TRANSACTION
-  SPI.endTransaction();
+  _spi.endTransaction();
 #endif
   
   //checkBusy();
@@ -2736,28 +2743,28 @@ uint8_t SX126XLT::receiveAddressed(uint8_t *rxbuffer, uint8_t size, uint32_t rxt
   RXend = RXstart + _RXPacketL;
   
   #ifdef USE_SPI_TRANSACTION     //to use SPI_TRANSACTION enable define at beginning of CPP file 
-  SPI.beginTransaction(SPISettings(LTspeedMaximum, LTdataOrder, LTdataMode));
+  _spi.beginTransaction(SPISettings(LTspeedMaximum, LTdataOrder, LTdataMode));
 #endif
 
   digitalWrite(_NSS, LOW);               //start the burst read
-  SPI.transfer(RADIO_READ_BUFFER);
-  SPI.transfer(RXstart);
-  SPI.transfer(0xFF);
+  _spi.transfer(RADIO_READ_BUFFER);
+  _spi.transfer(RXstart);
+  _spi.transfer(0xFF);
 
-  _RXPacketType = SPI.transfer(0);
-  _RXDestination = SPI.transfer(0);
-  _RXSource = SPI.transfer(0);
+  _RXPacketType = _spi.transfer(0);
+  _RXDestination = _spi.transfer(0);
+  _RXSource = _spi.transfer(0);
   
   for (index = RXstart; index < RXend; index++)
   {
-    regdata = SPI.transfer(0);
+    regdata = _spi.transfer(0);
     rxbuffer[index] = regdata;
   }
 
   digitalWrite(_NSS, HIGH);
   
   #ifdef USE_SPI_TRANSACTION
-  SPI.endTransaction();
+  _spi.endTransaction();
 #endif
   
   return _RXPacketL;                     //so we can check for packet having enough buffer space
@@ -3020,23 +3027,23 @@ void SX126XLT::fillSXBuffer(uint8_t startaddress, uint8_t size, uint8_t characte
   //writeRegister(REG_FIFOADDRPTR, startaddress);     //and save in FIFO access ptr
 
 #ifdef USE_SPI_TRANSACTION                          //to use SPI_TRANSACTION enable define at beginning of CPP file 
-  SPI.beginTransaction(SPISettings(LTspeedMaximum, LTdataOrder, LTdataMode));
+  _spi.beginTransaction(SPISettings(LTspeedMaximum, LTdataOrder, LTdataMode));
 #endif
 
   digitalWrite(_NSS, LOW);
-  SPI.transfer(RADIO_WRITE_BUFFER);
-  SPI.transfer(startaddress);
+  _spi.transfer(RADIO_WRITE_BUFFER);
+  _spi.transfer(startaddress);
   //SPI interface ready for byte to write to buffer
   
   for (index = 0; index < size; index++)
   {
-    SPI.transfer(character);
+    _spi.transfer(character);
   }
 
   digitalWrite(_NSS, HIGH);
 
 #ifdef USE_SPI_TRANSACTION
-  SPI.endTransaction();
+  _spi.endTransaction();
 #endif
 
 }
@@ -3064,24 +3071,24 @@ uint8_t SX126XLT::readPacket(uint8_t *rxbuffer, uint8_t size)
   RXend = RXstart + _RXPacketL;
 
   #ifdef USE_SPI_TRANSACTION     //to use SPI_TRANSACTION enable define at beginning of CPP file 
-  SPI.beginTransaction(SPISettings(LTspeedMaximum, LTdataOrder, LTdataMode));
+  _spi.beginTransaction(SPISettings(LTspeedMaximum, LTdataOrder, LTdataMode));
 #endif
   
   digitalWrite(_NSS, LOW);               //start the burst read
-  SPI.transfer(RADIO_READ_BUFFER);
-  SPI.transfer(RXstart);
-  SPI.transfer(0xFF);
+  _spi.transfer(RADIO_READ_BUFFER);
+  _spi.transfer(RXstart);
+  _spi.transfer(0xFF);
 
   for (index = RXstart; index < RXend; index++)
   {
-    regdata = SPI.transfer(0);
+    regdata = _spi.transfer(0);
     rxbuffer[index] = regdata;
   }
 
   digitalWrite(_NSS, HIGH);
   
   #ifdef USE_SPI_TRANSACTION
-  SPI.endTransaction();
+  _spi.endTransaction();
 #endif
 
   return _RXPacketL;                     //so we can check for packet having enough buffer space
@@ -3097,17 +3104,17 @@ void SX126XLT::writeByteSXBuffer(uint8_t addr, uint8_t regdata)
   setMode(MODE_STDBY_RC);                 //this is needed to ensure we can write to buffer OK.
 
 #ifdef USE_SPI_TRANSACTION                //to use SPI_TRANSACTION enable define at beginning of CPP file 
-  SPI.beginTransaction(SPISettings(LTspeedMaximum, LTdataOrder, LTdataMode));
+  _spi.beginTransaction(SPISettings(LTspeedMaximum, LTdataOrder, LTdataMode));
 #endif
 
   digitalWrite(_NSS, LOW);
-  SPI.transfer(RADIO_WRITE_BUFFER);
-  SPI.transfer(addr);
-  SPI.transfer(regdata);
+  _spi.transfer(RADIO_WRITE_BUFFER);
+  _spi.transfer(addr);
+  _spi.transfer(regdata);
   digitalWrite(_NSS, HIGH);
 
   #ifdef USE_SPI_TRANSACTION
-  SPI.endTransaction();
+  _spi.endTransaction();
   #endif
 
 }

--- a/src/SX126XLT.h
+++ b/src/SX126XLT.h
@@ -29,10 +29,14 @@
   
 **************************************************************************/
 
+class SPIClass; // forward declaration
+
 class SX126XLT  {
   public:
 
     SX126XLT();
+
+    void setSpi(SPIClass& spi);
 
     bool begin(int8_t pinNSS, int8_t pinNRESET, int8_t pinRFBUSY, int8_t pinDIO1, int8_t pinDIO2, int8_t pinDIO3, int8_t pinRXEN, int8_t pinTXEN, int8_t pinSW, uint8_t device);
     bool begin(int8_t pinNSS, int8_t pinNRESET, int8_t pinRFBUSY, int8_t pinDIO1, uint8_t device);
@@ -221,6 +225,7 @@ class SX126XLT  {
     uint8_t _freqregH, _freqregMH, _freqregML,_freqregL;  //the registers values for the set frequency
     uint8_t _ShiftfreqregH, _ShiftfreqregMH, _ShiftfreqregML, _ShiftfreqregL;  //register values for shifted frequency, used in FSK
 
+    SPIClass& _spi; // device to be used for SPI communication
 };
 #endif
 

--- a/src/SX127XLT.cpp
+++ b/src/SX127XLT.cpp
@@ -28,9 +28,16 @@
 
 
 SX127XLT::SX127XLT()
+    : _spi(SPI)
 {
 
 }
+
+void SX127XLT::setSpi(SPIClass& spi)
+{
+    _spi = spi;
+}
+
 
 /* Formats for :begin
   1 original   > begin(int8_t pinNSS, int8_t pinNRESET, int8_t pinDIO0, int8_t pinDIO1, int8_t pinDIO2, uint8_t device);
@@ -479,16 +486,16 @@ void SX127XLT::writeRegister(uint8_t address, uint8_t value)
 #endif
 
 #ifdef USE_SPI_TRANSACTION                  //to use SPI_TRANSACTION enable define at beginning of CPP file 
-  SPI.beginTransaction(SPISettings(LTspeedMaximum, LTdataOrder, LTdataMode));
+  _spi.beginTransaction(SPISettings(LTspeedMaximum, LTdataOrder, LTdataMode));
 #endif
 
   digitalWrite(_NSS, LOW);                  //set NSS low
-  SPI.transfer(address | 0x80);             //mask address for write
-  SPI.transfer(value);                      //write the byte
+  _spi.transfer(address | 0x80);             //mask address for write
+  _spi.transfer(value);                      //write the byte
   digitalWrite(_NSS, HIGH);                 //set NSS high
 
 #ifdef USE_SPI_TRANSACTION
-  SPI.endTransaction();
+  _spi.endTransaction();
 #endif
 
 #ifdef SX127XDEBUG2
@@ -511,16 +518,16 @@ uint8_t SX127XLT::readRegister(uint8_t address)
   uint8_t regdata;
 
 #ifdef USE_SPI_TRANSACTION         //to use SPI_TRANSACTION enable define at beginning of CPP file 
-  SPI.beginTransaction(SPISettings(LTspeedMaximum, LTdataOrder, LTdataMode));
+  _spi.beginTransaction(SPISettings(LTspeedMaximum, LTdataOrder, LTdataMode));
 #endif
 
   digitalWrite(_NSS, LOW);         //set NSS low
-  SPI.transfer(address & 0x7F);    //mask address for read
-  regdata = SPI.transfer(0);       //read the byte
+  _spi.transfer(address & 0x7F);    //mask address for read
+  regdata = _spi.transfer(0);       //read the byte
   digitalWrite(_NSS, HIGH);        //set NSS high
 
 #ifdef USE_SPI_TRANSACTION
-  SPI.endTransaction();
+  _spi.endTransaction();
 #endif
 
 #ifdef SX127XDEBUG2
@@ -2201,21 +2208,21 @@ uint8_t SX127XLT::receive(uint8_t *rxbuffer, uint8_t size, uint32_t rxtimeout, u
   }
 
 #ifdef USE_SPI_TRANSACTION   //to use SPI_TRANSACTION enable define at beginning of CPP file 
-  SPI.beginTransaction(SPISettings(LTspeedMaximum, LTdataOrder, LTdataMode));
+  _spi.beginTransaction(SPISettings(LTspeedMaximum, LTdataOrder, LTdataMode));
 #endif
 
   digitalWrite(_NSS, LOW);                    //start the burst read
-  SPI.transfer(REG_FIFO);
+  _spi.transfer(REG_FIFO);
 
   for (index = 0; index < _RXPacketL; index++)
   {
-    regdata = SPI.transfer(0);
+    regdata = _spi.transfer(0);
     rxbuffer[index] = regdata;
   }
   digitalWrite(_NSS, HIGH);
 
 #ifdef USE_SPI_TRANSACTION
-  SPI.endTransaction();
+  _spi.endTransaction();
 #endif
 
   return _RXPacketL;                           //so we can check for packet having enough buffer space
@@ -2275,25 +2282,25 @@ uint8_t SX127XLT::receiveAddressed(uint8_t *rxbuffer, uint8_t size, uint32_t rxt
   }
 
 #ifdef USE_SPI_TRANSACTION   //to use SPI_TRANSACTION enable define at beginning of CPP file 
-  SPI.beginTransaction(SPISettings(LTspeedMaximum, LTdataOrder, LTdataMode));
+  _spi.beginTransaction(SPISettings(LTspeedMaximum, LTdataOrder, LTdataMode));
 #endif
 
   digitalWrite(_NSS, LOW);                    //start the burst read
-  SPI.transfer(REG_FIFO);
+  _spi.transfer(REG_FIFO);
 
-  _RXPacketType = SPI.transfer(0);
-  _RXDestination = SPI.transfer(0);
-  _RXSource = SPI.transfer(0);
+  _RXPacketType = _spi.transfer(0);
+  _RXDestination = _spi.transfer(0);
+  _RXSource = _spi.transfer(0);
 
   for (index = 0; index < _RXPacketL; index++)
   {
-    regdata = SPI.transfer(0);
+    regdata = _spi.transfer(0);
     rxbuffer[index] = regdata;
   }
   digitalWrite(_NSS, HIGH);
 
 #ifdef USE_SPI_TRANSACTION
-  SPI.endTransaction();
+  _spi.endTransaction();
 #endif
 
   return _RXPacketL;                             //so we can check for packet having enough buffer space
@@ -2325,21 +2332,21 @@ uint8_t SX127XLT::readPacket(uint8_t *rxbuffer, uint8_t size)
   }
 
 #ifdef USE_SPI_TRANSACTION   //to use SPI_TRANSACTION enable define at beginning of CPP file 
-  SPI.beginTransaction(SPISettings(LTspeedMaximum, LTdataOrder, LTdataMode));
+  _spi.beginTransaction(SPISettings(LTspeedMaximum, LTdataOrder, LTdataMode));
 #endif
 
   digitalWrite(_NSS, LOW);                    //start the burst read
-  SPI.transfer(REG_FIFO);
+  _spi.transfer(REG_FIFO);
 
   for (index = 0; index < _RXPacketL; index++)
   {
-    regdata = SPI.transfer(0);
+    regdata = _spi.transfer(0);
     rxbuffer[index] = regdata;
   }
   digitalWrite(_NSS, HIGH);
 
 #ifdef USE_SPI_TRANSACTION
-  SPI.endTransaction();
+  _spi.endTransaction();
 #endif
 
   return _RXPacketL;                           //so we can check for packet having enough buffer space
@@ -2366,24 +2373,24 @@ uint8_t SX127XLT::readPacketAddressed(uint8_t *rxbuffer, uint8_t size)
   }
 
 #ifdef USE_SPI_TRANSACTION   //to use SPI_TRANSACTION enable define at beginning of CPP file 
-  SPI.beginTransaction(SPISettings(LTspeedMaximum, LTdataOrder, LTdataMode));
+  _spi.beginTransaction(SPISettings(LTspeedMaximum, LTdataOrder, LTdataMode));
 #endif
 
   digitalWrite(_NSS, LOW);                    //start the burst read
-  SPI.transfer(REG_FIFO);
-  _RXPacketType = SPI.transfer(0);
-  _RXDestination = SPI.transfer(0);
-  _RXSource = SPI.transfer(0);
+  _spi.transfer(REG_FIFO);
+  _RXPacketType = _spi.transfer(0);
+  _RXDestination = _spi.transfer(0);
+  _RXSource = _spi.transfer(0);
 
   for (index = 0; index < _RXPacketL; index++)
   {
-    regdata = SPI.transfer(0);
+    regdata = _spi.transfer(0);
     rxbuffer[index] = regdata;
   }
   digitalWrite(_NSS, HIGH);
 
 #ifdef USE_SPI_TRANSACTION
-  SPI.endTransaction();
+  _spi.endTransaction();
 #endif
 
   return _RXPacketL;                           //so we can check for packet having enough buffer space
@@ -2410,21 +2417,21 @@ uint8_t SX127XLT::transmit(uint8_t *txbuffer, uint8_t size, uint32_t txtimeout, 
   writeRegister(REG_FIFOADDRPTR, ptr);          //and save in FIFO access ptr
 
 #ifdef USE_SPI_TRANSACTION                   //to use SPI_TRANSACTION enable define at beginning of CPP file 
-  SPI.beginTransaction(SPISettings(LTspeedMaximum, LTdataOrder, LTdataMode));
+  _spi.beginTransaction(SPISettings(LTspeedMaximum, LTdataOrder, LTdataMode));
 #endif
 
   digitalWrite(_NSS, LOW);
-  SPI.transfer(WREG_FIFO);
+  _spi.transfer(WREG_FIFO);
 
   for (index = 0; index < size; index++)
   {
     bufferdata = txbuffer[index];
-    SPI.transfer(bufferdata);
+    _spi.transfer(bufferdata);
   }
   digitalWrite(_NSS, HIGH);
 
 #ifdef USE_SPI_TRANSACTION
-  SPI.endTransaction();
+  _spi.endTransaction();
 #endif
 
   _TXPacketL = size;
@@ -2482,25 +2489,25 @@ uint8_t SX127XLT::transmitAddressed(uint8_t *txbuffer, uint8_t size, char txpack
   writeRegister(REG_FIFOADDRPTR, ptr);            //and save in FIFO access ptr
 
 #ifdef USE_SPI_TRANSACTION                        //to use SPI_TRANSACTION enable define at beginning of CPP file 
-  SPI.beginTransaction(SPISettings(LTspeedMaximum, LTdataOrder, LTdataMode));
+  _spi.beginTransaction(SPISettings(LTspeedMaximum, LTdataOrder, LTdataMode));
 #endif
 
   digitalWrite(_NSS, LOW);
-  SPI.transfer(WREG_FIFO);
-  SPI.transfer(txpackettype);                     //Write the packet type
-  SPI.transfer(txdestination);                    //Destination node
-  SPI.transfer(txsource);                         //Source node
+  _spi.transfer(WREG_FIFO);
+  _spi.transfer(txpackettype);                     //Write the packet type
+  _spi.transfer(txdestination);                    //Destination node
+  _spi.transfer(txsource);                         //Source node
   _TXPacketL = 3 + size;                          //we have added 3 header bytes to size
 
   for (index = 0; index < size; index++)
   {
     bufferdata = txbuffer[index];
-    SPI.transfer(bufferdata);
+    _spi.transfer(bufferdata);
   }
   digitalWrite(_NSS, HIGH);
 
 #ifdef USE_SPI_TRANSACTION
-  SPI.endTransaction();
+  _spi.endTransaction();
 #endif
 
   writeRegister(REG_PAYLOADLENGTH, _TXPacketL);
@@ -2953,15 +2960,15 @@ void SX127XLT::printSXBufferHEX(uint8_t start, uint8_t end)
   writeRegister(REG_FIFOADDRPTR, start);         //set FIFO access ptr to start
 
 #ifdef USE_SPI_TRANSACTION                       //to use SPI_TRANSACTION enable define at beginning of CPP file 
-  SPI.beginTransaction(SPISettings(LTspeedMaximum, LTdataOrder, LTdataMode));
+  _spi.beginTransaction(SPISettings(LTspeedMaximum, LTdataOrder, LTdataMode));
 #endif
 
   digitalWrite(_NSS, LOW);                       //start the burst read
-  SPI.transfer(REG_FIFO);
+  _spi.transfer(REG_FIFO);
 
   for (index = start; index <= end; index++)
   {
-    regdata = SPI.transfer(0);
+    regdata = _spi.transfer(0);
     printHEXByte(regdata);
     Serial.print(F(" "));
 
@@ -2969,7 +2976,7 @@ void SX127XLT::printSXBufferHEX(uint8_t start, uint8_t end)
   digitalWrite(_NSS, HIGH);
 
 #ifdef USE_SPI_TRANSACTION
-  SPI.endTransaction();
+  _spi.endTransaction();
 #endif
 
 }
@@ -2987,21 +2994,21 @@ void SX127XLT::printSXBufferASCII(uint8_t start, uint8_t end)
   writeRegister(REG_FIFOADDRPTR, start);      //and save in FIFO access ptr
 
 #ifdef USE_SPI_TRANSACTION                    //to use SPI_TRANSACTION enable define at beginning of CPP file 
-  SPI.beginTransaction(SPISettings(LTspeedMaximum, LTdataOrder, LTdataMode));
+  _spi.beginTransaction(SPISettings(LTspeedMaximum, LTdataOrder, LTdataMode));
 #endif
 
   digitalWrite(_NSS, LOW);                    //start the burst read
-  SPI.transfer(REG_FIFO);
+  _spi.transfer(REG_FIFO);
 
   for (index = start; index <= end; index++)
   {
-    regdata = SPI.transfer(0);
+    regdata = _spi.transfer(0);
     Serial.write(regdata);
   }
   digitalWrite(_NSS, HIGH);
 
 #ifdef USE_SPI_TRANSACTION
-  SPI.endTransaction();
+  _spi.endTransaction();
 #endif
 }
 
@@ -3017,21 +3024,21 @@ void SX127XLT::fillSXBuffer(uint8_t startaddress, uint8_t size, uint8_t characte
   writeRegister(REG_FIFOADDRPTR, startaddress);     //and save in FIFO access ptr
 
 #ifdef USE_SPI_TRANSACTION                          //to use SPI_TRANSACTION enable define at beginning of CPP file 
-  SPI.beginTransaction(SPISettings(LTspeedMaximum, LTdataOrder, LTdataMode));
+  _spi.beginTransaction(SPISettings(LTspeedMaximum, LTdataOrder, LTdataMode));
 #endif
 
   digitalWrite(_NSS, LOW);                          //start the burst write
-  SPI.transfer(WREG_FIFO);
+  _spi.transfer(WREG_FIFO);
 
   for (index = 0; index < size; index++)
   {
-    SPI.transfer(character);
+    _spi.transfer(character);
   }
 
   digitalWrite(_NSS, HIGH);
 
 #ifdef USE_SPI_TRANSACTION
-  SPI.endTransaction();
+  _spi.endTransaction();
 #endif
 }
 
@@ -3048,16 +3055,16 @@ uint8_t SX127XLT::getByteSXBuffer(uint8_t addr)
   writeRegister(REG_FIFOADDRPTR, addr);       //set FIFO access ptr to location
 
 #ifdef USE_SPI_TRANSACTION                    //to use SPI_TRANSACTION enable define at beginning of CPP file 
-  SPI.beginTransaction(SPISettings(LTspeedMaximum, LTdataOrder, LTdataMode));
+  _spi.beginTransaction(SPISettings(LTspeedMaximum, LTdataOrder, LTdataMode));
 #endif
 
   digitalWrite(_NSS, LOW);                    //start the burst read
-  SPI.transfer(REG_FIFO);
-  regdata = SPI.transfer(0);
+  _spi.transfer(REG_FIFO);
+  regdata = _spi.transfer(0);
   digitalWrite(_NSS, HIGH);
 
 #ifdef USE_SPI_TRANSACTION
-  SPI.endTransaction();
+  _spi.endTransaction();
 #endif
 
   return regdata;
@@ -3075,16 +3082,16 @@ void SX127XLT::writeByteSXBuffer(uint8_t addr, uint8_t regdata)
   writeRegister(REG_FIFOADDRPTR, addr);   //set FIFO access ptr to location
 
 #ifdef USE_SPI_TRANSACTION                //to use SPI_TRANSACTION enable define at beginning of CPP file 
-  SPI.beginTransaction(SPISettings(LTspeedMaximum, LTdataOrder, LTdataMode));
+  _spi.beginTransaction(SPISettings(LTspeedMaximum, LTdataOrder, LTdataMode));
 #endif
 
   digitalWrite(_NSS, LOW);                //start the burst read
-  SPI.transfer(WREG_FIFO);
-  SPI.transfer(regdata);
+  _spi.transfer(WREG_FIFO);
+  _spi.transfer(regdata);
   digitalWrite(_NSS, HIGH);
 
 #ifdef USE_SPI_TRANSACTION
-  SPI.endTransaction();
+  _spi.endTransaction();
 #endif
 }
 
@@ -3101,11 +3108,11 @@ void SX127XLT::startWriteSXBuffer(uint8_t ptr)
   writeRegister(REG_FIFOADDRPTR, ptr);          //set buffer access ptr
 
 #ifdef USE_SPI_TRANSACTION                      //to use SPI_TRANSACTION enable define at beginning of CPP file 
-  SPI.beginTransaction(SPISettings(LTspeedMaximum, LTdataOrder, LTdataMode));
+  _spi.beginTransaction(SPISettings(LTspeedMaximum, LTdataOrder, LTdataMode));
 #endif
 
   digitalWrite(_NSS, LOW);
-  SPI.transfer(WREG_FIFO);
+  _spi.transfer(WREG_FIFO);
 }
 
 
@@ -3118,7 +3125,7 @@ uint8_t SX127XLT::endWriteSXBuffer()
   digitalWrite(_NSS, HIGH);
 
 #ifdef USE_SPI_TRANSACTION
-  SPI.endTransaction();
+  _spi.endTransaction();
 #endif
 
   return _TXPacketL;
@@ -3136,13 +3143,13 @@ void SX127XLT::startReadSXBuffer(uint8_t ptr)
   writeRegister(REG_FIFOADDRPTR, ptr);           //set buffer access ptr
 
 #ifdef USE_SPI_TRANSACTION                       //to use SPI_TRANSACTION enable define at beginning of CPP file 
-  SPI.beginTransaction(SPISettings(LTspeedMaximum, LTdataOrder, LTdataMode));
+  _spi.beginTransaction(SPISettings(LTspeedMaximum, LTdataOrder, LTdataMode));
 #endif
 
   digitalWrite(_NSS, LOW);                       //start the burst read
-  SPI.transfer(REG_FIFO);
+  _spi.transfer(REG_FIFO);
 
-  //next line would be data = SPI.transfer(0);
+  //next line would be data = _spi.transfer(0);
   //SPI interface ready for byte to read from
 }
 
@@ -3156,7 +3163,7 @@ uint8_t SX127XLT::endReadSXBuffer()
   digitalWrite(_NSS, HIGH);
 
 #ifdef USE_SPI_TRANSACTION
-  SPI.endTransaction();
+  _spi.endTransaction();
 #endif
 
   return _RXPacketL;
@@ -3169,7 +3176,7 @@ void SX127XLT::writeUint8(uint8_t x)
   Serial.println(F("writeUint8() "));
 #endif
 
-  SPI.transfer(x);
+  _spi.transfer(x);
 
   _TXPacketL++;                      //increment count of bytes written
 }
@@ -3183,7 +3190,7 @@ uint8_t SX127XLT::readUint8()
 
   uint8_t x;
 
-  x = SPI.transfer(0);
+  x = _spi.transfer(0);
 
   _RXPacketL++;                       //increment count of bytes read
   return (x);
@@ -3196,7 +3203,7 @@ void SX127XLT::writeInt8(int8_t x)
   Serial.println(F("writeInt8() "));
 #endif
 
-  SPI.transfer(x);
+  _spi.transfer(x);
 
   _TXPacketL++;                      //increment count of bytes written
 }
@@ -3210,7 +3217,7 @@ int8_t SX127XLT::readInt8()
 
   int8_t x;
 
-  x = SPI.transfer(0);
+  x = _spi.transfer(0);
 
   _RXPacketL++;                      //increment count of bytes read
   return (x);
@@ -3223,7 +3230,7 @@ void SX127XLT::writeChar(char x)
   Serial.println(F("writeChar() "));
 #endif
 
-  SPI.transfer(x);
+  _spi.transfer(x);
 
   _TXPacketL++;                     //increment count of bytes written
 }
@@ -3237,7 +3244,7 @@ char SX127XLT::readChar()
 
   char x;
 
-  x = SPI.transfer(0);
+  x = _spi.transfer(0);
 
   _RXPacketL++;                      //increment count of bytes read
   return (x);
@@ -3250,8 +3257,8 @@ void SX127XLT::writeUint16(uint16_t x)
   Serial.println(F("writeUint16() "));
 #endif
 
-  SPI.transfer(lowByte(x));
-  SPI.transfer(highByte(x));
+  _spi.transfer(lowByte(x));
+  _spi.transfer(highByte(x));
 
   _TXPacketL = _TXPacketL + 2;         //increment count of bytes written
 }
@@ -3265,8 +3272,8 @@ uint16_t SX127XLT::readUint16()
 
   uint8_t lowbyte, highbyte;
 
-  lowbyte = SPI.transfer(0);
-  highbyte = SPI.transfer(0);
+  lowbyte = _spi.transfer(0);
+  highbyte = _spi.transfer(0);
 
   _RXPacketL = _RXPacketL + 2;         //increment count of bytes read
   return ((highbyte << 8) + lowbyte);
@@ -3279,8 +3286,8 @@ void SX127XLT::writeInt16(int16_t x)
   Serial.println(F("writeInt16() "));
 #endif
 
-  SPI.transfer(lowByte(x));
-  SPI.transfer(highByte(x));
+  _spi.transfer(lowByte(x));
+  _spi.transfer(highByte(x));
 
   _TXPacketL = _TXPacketL + 2;         //increment count of bytes written
 }
@@ -3294,8 +3301,8 @@ int16_t SX127XLT::readInt16()
 
   uint8_t lowbyte, highbyte;
 
-  lowbyte = SPI.transfer(0);
-  highbyte = SPI.transfer(0);
+  lowbyte = _spi.transfer(0);
+  highbyte = _spi.transfer(0);
 
   _RXPacketL = _RXPacketL + 2;         //increment count of bytes read
   return ((highbyte << 8) + lowbyte);
@@ -3320,7 +3327,7 @@ void SX127XLT::writeUint32(uint32_t x)
   for (i = 0; i < 4; i++)
   {
     j = data.b[i];
-    SPI.transfer(j);
+    _spi.transfer(j);
   }
 
   _TXPacketL = _TXPacketL + 4;         //increment count of bytes written
@@ -3343,7 +3350,7 @@ uint32_t SX127XLT::readUint32()
 
   for (i = 0; i < 4; i++)
   {
-    j = SPI.transfer(0);
+    j = _spi.transfer(0);
     readdata.b[i] = j;
   }
   _RXPacketL = _RXPacketL + 4;         //increment count of bytes read
@@ -3369,7 +3376,7 @@ void SX127XLT::writeInt32(int32_t x)
   for (i = 0; i < 4; i++)
   {
     j = data.b[i];
-    SPI.transfer(j);
+    _spi.transfer(j);
   }
 
   _TXPacketL = _TXPacketL + 4;         //increment count of bytes written
@@ -3392,7 +3399,7 @@ int32_t SX127XLT::readInt32()
 
   for (i = 0; i < 4; i++)
   {
-    j = SPI.transfer(0);
+    j = _spi.transfer(0);
     readdata.b[i] = j;
   }
   _RXPacketL = _RXPacketL + 4;         //increment count of bytes read
@@ -3418,7 +3425,7 @@ void SX127XLT::writeFloat(float x)
   for (i = 0; i < 4; i++)
   {
     j = data.b[i];
-    SPI.transfer(j);
+    _spi.transfer(j);
   }
 
   _TXPacketL = _TXPacketL + 4;         //increment count of bytes written
@@ -3441,7 +3448,7 @@ float SX127XLT::readFloat()
 
   for (i = 0; i < 4; i++)
   {
-    j = SPI.transfer(0);
+    j = _spi.transfer(0);
     readdata.b[i] = j;
   }
   _RXPacketL = _RXPacketL + 4;         //increment count of bytes read
@@ -3464,10 +3471,10 @@ void SX127XLT::writeBuffer(uint8_t *txbuffer, uint8_t size)
   for (index = 0; index < size; index++)
   {
     regdata = txbuffer[index];
-    SPI.transfer(regdata);
+    _spi.transfer(regdata);
   }
 
-  SPI.transfer(0);                     //this ensures last byte of buffer writen really is a null (0)
+  _spi.transfer(0);                     //this ensures last byte of buffer writen really is a null (0)
 }
 
 
@@ -3487,10 +3494,10 @@ void SX127XLT::writeBufferChar(char *txbuffer, uint8_t size)
   for (index = 0; index < size; index++)
   {
     regdata = txbuffer[index];
-    SPI.transfer(regdata);
+    _spi.transfer(regdata);
   }
 
-  SPI.transfer(0);                     //this ensures last byte of buffer writen really is a null (0)
+  _spi.transfer(0);                     //this ensures last byte of buffer writen really is a null (0)
 }
 
 
@@ -3506,13 +3513,13 @@ void SX127XLT::writeBufferChar(char *txbuffer)
  do
   {
     regdata = txbuffer[index];           //read data from txbuffer
-    SPI.transfer(regdata);               //write to device buffer 
+    _spi.transfer(regdata);               //write to device buffer 
     index++;
   } while (regdata != 0);                //keep reading until we have reached the null (0) at the buffer end or exceeded size of buffer allowed
 
   _TXPacketL = _TXPacketL + index;       //increment count of bytes written
 
-  SPI.transfer(0);                       //this ensures last byte of buffer writen really is a null (0)
+  _spi.transfer(0);                       //this ensures last byte of buffer writen really is a null (0)
 }
 
 
@@ -3527,7 +3534,7 @@ uint8_t SX127XLT::readBuffer(uint8_t *rxbuffer)
 
   do
   {
-    regdata = SPI.transfer(0);
+    regdata = _spi.transfer(0);
     rxbuffer[index] = regdata;           //fill the rxbuffer.
     index++;
   } while (regdata != 0);                //keep reading until we have reached the null (0) at the buffer end or exceeded size of buffer allowed
@@ -3548,7 +3555,7 @@ uint8_t SX127XLT::readBuffer(uint8_t *rxbuffer, uint8_t size)
   
   for (index = 0; index <= size; index++)
   {
-   regdata = SPI.transfer(0);
+   regdata = _spi.transfer(0);
    rxbuffer[index] = regdata;            //fill the rxbuffer.
   }
   
@@ -3569,7 +3576,7 @@ uint8_t SX127XLT::readBufferChar(char *rxbuffer)
 
   do                                     
   {
-    regdata = SPI.transfer(0);
+    regdata = _spi.transfer(0);
     rxbuffer[index] = regdata;           //fill the buffer.
     index++;
   } while (regdata != 0);                //keep reading until we have reached the null (0) at the buffer end
@@ -3649,18 +3656,18 @@ void SX127XLT::toneFM(uint16_t frequency, uint32_t length, uint32_t deviation, f
   uint8_t freqregH, freqregM, freqregL;
 
 #ifdef USE_SPI_TRANSACTION           //to use SPI_TRANSACTION enable define at beginning of CPP file 
-  SPI.beginTransaction(SPISettings(LTspeedMaximum, LTdataOrder, LTdataMode));
+  _spi.beginTransaction(SPISettings(LTspeedMaximum, LTdataOrder, LTdataMode));
 #endif
 
   digitalWrite(_NSS, LOW);           //set NSS low
-  SPI.transfer(REG_FRMSB & 0x7F);    //mask address for read
-  freqregH = SPI.transfer(0);
-  freqregM = SPI.transfer(0);
-  freqregL = SPI.transfer(0);
+  _spi.transfer(REG_FRMSB & 0x7F);    //mask address for read
+  freqregH = _spi.transfer(0);
+  freqregM = _spi.transfer(0);
+  freqregL = _spi.transfer(0);
   digitalWrite(_NSS, HIGH);          //set NSS high
 
 #ifdef USE_SPI_TRANSACTION
-  SPI.endTransaction();
+  _spi.endTransaction();
 #endif
 
   freqreg = ( ( (uint32_t) freqregH << 16 ) | ( (uint32_t) freqregM << 8 ) | ( freqregL ) );
@@ -3724,39 +3731,39 @@ void SX127XLT::toneFM(uint16_t frequency, uint32_t length, uint32_t deviation, f
   setTXDirect();
 
 #ifdef USE_SPI_TRANSACTION                    //to use SPI_TRANSACTION enable define at beginning of CPP file 
-  SPI.beginTransaction(SPISettings(LTspeedMaximum, LTdataOrder, LTdataMode));
+  _spi.beginTransaction(SPISettings(LTspeedMaximum, LTdataOrder, LTdataMode));
 #endif
 
   for (index = 1; index <= loopcount; index++)
   {
     digitalWrite(_NSS, LOW);                  //set NSS low
-    SPI.transfer(0x86);                       //address for write to REG_FRMSB
-    SPI.transfer(ShiftH);
-    SPI.transfer(ShiftM);
-    SPI.transfer(ShiftL);
+    _spi.transfer(0x86);                       //address for write to REG_FRMSB
+    _spi.transfer(ShiftH);
+    _spi.transfer(ShiftM);
+    _spi.transfer(ShiftL);
     digitalWrite(_NSS, HIGH);                 //set NSS high
 
     delayMicroseconds(ToneDelayus);
 
     digitalWrite(_NSS, LOW);                  //set NSS low
-    SPI.transfer(0x86);                       //address for write to REG_FRMSB
-    SPI.transfer(NoShiftH);
-    SPI.transfer(NoShiftM);
-    SPI.transfer(NoShiftL);
+    _spi.transfer(0x86);                       //address for write to REG_FRMSB
+    _spi.transfer(NoShiftH);
+    _spi.transfer(NoShiftM);
+    _spi.transfer(NoShiftL);
     digitalWrite(_NSS, HIGH);                 //set NSS high
 
     delayMicroseconds(ToneDelayus);
   }
   //now set the frequency registers back to centre
   digitalWrite(_NSS, LOW);                  //set NSS low
-  SPI.transfer(0x86);                       //address for write to REG_FRMSB
-  SPI.transfer(freqregH);
-  SPI.transfer(freqregM);
-  SPI.transfer(freqregL);
+  _spi.transfer(0x86);                       //address for write to REG_FRMSB
+  _spi.transfer(freqregH);
+  _spi.transfer(freqregM);
+  _spi.transfer(freqregL);
   digitalWrite(_NSS, HIGH);                 //set NSS high
 
 #ifdef USE_SPI_TRANSACTION
-  SPI.endTransaction();
+  _spi.endTransaction();
 #endif
 
   writeRegister(REG_PLLHOP, 0x2D);          //restore PLLHOP register value
@@ -3854,18 +3861,18 @@ void SX127XLT::setRfFrequencyDirect(uint8_t high, uint8_t mid, uint8_t low)
 #endif
 
 #ifdef USE_SPI_TRANSACTION                  //to use SPI_TRANSACTION enable define at beginning of CPP file 
-  SPI.beginTransaction(SPISettings(LTspeedMaximum, LTdataOrder, LTdataMode));
+  _spi.beginTransaction(SPISettings(LTspeedMaximum, LTdataOrder, LTdataMode));
 #endif
 
   digitalWrite(_NSS, LOW);                  //set NSS low
-  SPI.transfer(0x86);                       //address for write to REG_FRMSB
-  SPI.transfer(high);
-  SPI.transfer(mid);
-  SPI.transfer(low);
+  _spi.transfer(0x86);                       //address for write to REG_FRMSB
+  _spi.transfer(high);
+  _spi.transfer(mid);
+  _spi.transfer(low);
   digitalWrite(_NSS, HIGH);                 //set NSS high
 
 #ifdef USE_SPI_TRANSACTION
-  SPI.endTransaction();
+  _spi.endTransaction();
 #endif
 }
 
@@ -3879,18 +3886,18 @@ void SX127XLT::getRfFrequencyRegisters(uint8_t *buff)
 #endif
 
 #ifdef USE_SPI_TRANSACTION         //to use SPI_TRANSACTION enable define at beginning of CPP file 
-  SPI.beginTransaction(SPISettings(LTspeedMaximum, LTdataOrder, LTdataMode));
+  _spi.beginTransaction(SPISettings(LTspeedMaximum, LTdataOrder, LTdataMode));
 #endif
 
   digitalWrite(_NSS, LOW);                  //set NSS low
-  SPI.transfer(REG_FRMSB & 0x7F);           //mask address for read
-  buff[0] = SPI.transfer(0);                //read the byte into buffer
-  buff[1] = SPI.transfer(0);                //read the byte into buffer
-  buff[2] = SPI.transfer(0);                //read the byte into buffer
+  _spi.transfer(REG_FRMSB & 0x7F);           //mask address for read
+  buff[0] = _spi.transfer(0);                //read the byte into buffer
+  buff[1] = _spi.transfer(0);                //read the byte into buffer
+  buff[2] = _spi.transfer(0);                //read the byte into buffer
   digitalWrite(_NSS, HIGH);                 //set NSS high
 
 #ifdef USE_SPI_TRANSACTION
-  SPI.endTransaction();
+  _spi.endTransaction();
 #endif
 }
 
@@ -4198,7 +4205,7 @@ uint8_t SX127XLT::readBufferbytes(uint8_t *buffer, uint8_t size)
 
   for (index = 1; index <= size; index++)
   {
-    regdata = SPI.transfer(0);
+    regdata = _spi.transfer(0);
     buffer[ptr] = regdata;              //fill the buffer.
     ptr++;
   }
@@ -4220,7 +4227,7 @@ uint8_t SX127XLT::writeBufferbytes(uint8_t *buffer, uint8_t size)
   for (index = 0; index < size; index++)
   {
     regdata = buffer[index];
-    SPI.transfer(regdata);                                                
+    _spi.transfer(regdata);                                                
   }
 
   _TXPacketL = _TXPacketL + size;       //increment count of bytes read and written to buffer

--- a/src/SX127XLT.h
+++ b/src/SX127XLT.h
@@ -12,6 +12,7 @@
 #include <Arduino.h>
 #include <SX127XLT_Definitions.h>
 
+class SPIClass; // forward declaration
 
 class SX127XLT
 {
@@ -20,6 +21,8 @@ class SX127XLT
 
     SX127XLT();
 
+    void setSpi(SPIClass& spi);
+    
     bool begin(int8_t pinNSS, int8_t pinNRESET, int8_t pinDIO0, int8_t pinDIO1, int8_t pinDIO2, uint8_t device);
     bool begin(int8_t pinNSS, int8_t pinNRESET, int8_t pinDIO0, uint8_t device);
     bool begin(int8_t pinNSS, uint8_t device);
@@ -240,6 +243,8 @@ class SX127XLT
     uint8_t _ShiftfreqregH, _ShiftfreqregM, _ShiftfreqregL;  //register values for shifted frequency, used in FSK RTTY etc
     uint32_t _savedFrequency;       //when setRfFrequency() is used the set frequency is saved
     int32_t _savedOffset;           //when setRfFrequency() is used the set offset is saved
+
+    SPIClass& _spi; // device to be used for SPI communication
 };
 #endif
 

--- a/src/SX128XLT.cpp
+++ b/src/SX128XLT.cpp
@@ -21,7 +21,13 @@ See LICENSE.TXT file included in the library
 //#define SX128XDEBUGPINS           //enable pin allocation debug messages
 
 SX128XLT::SX128XLT()
+    : _spi(SPI)
 {
+}
+
+void SX128XLT::setSpi(SPIClass& spi)
+{
+    _spi = spi;
 }
 
 /* Formats for :begin
@@ -340,23 +346,23 @@ void SX128XLT::readRegisters(uint16_t address, uint8_t *buffer, uint16_t size)
   checkBusy();
 
 #ifdef USE_SPI_TRANSACTION     //to use SPI_TRANSACTION enable define at beginning of CPP file 
-  SPI.beginTransaction(SPISettings(LTspeedMaximum, LTdataOrder, LTdataMode));
+  _spi.beginTransaction(SPISettings(LTspeedMaximum, LTdataOrder, LTdataMode));
 #endif
 
   digitalWrite(_NSS, LOW);
-  SPI.transfer(RADIO_READ_REGISTER);
-  SPI.transfer(addr_h);               //MSB
-  SPI.transfer(addr_l);               //LSB
-  SPI.transfer(0xFF);
+  _spi.transfer(RADIO_READ_REGISTER);
+  _spi.transfer(addr_h);               //MSB
+  _spi.transfer(addr_l);               //LSB
+  _spi.transfer(0xFF);
   for (index = 0; index < size; index++)
   {
-    *(buffer + index) = SPI.transfer(0xFF);
+    *(buffer + index) = _spi.transfer(0xFF);
   }
 
   digitalWrite(_NSS, HIGH);
 
 #ifdef USE_SPI_TRANSACTION
-  SPI.endTransaction();
+  _spi.endTransaction();
 #endif
 
 }
@@ -388,23 +394,23 @@ void SX128XLT::writeRegisters(uint16_t address, uint8_t *buffer, uint16_t size)
   checkBusy();
 
 #ifdef USE_SPI_TRANSACTION     //to use SPI_TRANSACTION enable define at beginning of CPP file 
-  SPI.beginTransaction(SPISettings(LTspeedMaximum, LTdataOrder, LTdataMode));
+  _spi.beginTransaction(SPISettings(LTspeedMaximum, LTdataOrder, LTdataMode));
 #endif
 
   digitalWrite(_NSS, LOW);
-  SPI.transfer(RADIO_WRITE_REGISTER);
-  SPI.transfer(addr_h);   //MSB
-  SPI.transfer(addr_l);   //LSB
+  _spi.transfer(RADIO_WRITE_REGISTER);
+  _spi.transfer(addr_h);   //MSB
+  _spi.transfer(addr_l);   //LSB
 
   for (i = 0; i < size; i++)
   {
-    SPI.transfer(buffer[i]);
+    _spi.transfer(buffer[i]);
   }
 
   digitalWrite(_NSS, HIGH);
 
 #ifdef USE_SPI_TRANSACTION
-  SPI.endTransaction();
+  _spi.endTransaction();
 #endif
 
   //checkBusy();
@@ -432,20 +438,20 @@ void SX128XLT::writeCommand(uint8_t Opcode, uint8_t *buffer, uint16_t size)
   checkBusy();
 
 #ifdef USE_SPI_TRANSACTION     //to use SPI_TRANSACTION enable define at beginning of CPP file 
-  SPI.beginTransaction(SPISettings(LTspeedMaximum, LTdataOrder, LTdataMode));
+  _spi.beginTransaction(SPISettings(LTspeedMaximum, LTdataOrder, LTdataMode));
 #endif
 
   digitalWrite(_NSS, LOW);
-  SPI.transfer(Opcode);
+  _spi.transfer(Opcode);
 
   for (index = 0; index < size; index++)
   {
-    SPI.transfer(buffer[index]);
+    _spi.transfer(buffer[index]);
   }
   digitalWrite(_NSS, HIGH);
 
 #ifdef USE_SPI_TRANSACTION
-  SPI.endTransaction();
+  _spi.endTransaction();
 #endif
 
   if (Opcode != RADIO_SET_SLEEP)
@@ -466,22 +472,22 @@ void SX128XLT::readCommand(uint8_t Opcode, uint8_t *buffer, uint16_t size)
 
 
 #ifdef USE_SPI_TRANSACTION     //to use SPI_TRANSACTION enable define at beginning of CPP file 
-  SPI.beginTransaction(SPISettings(LTspeedMaximum, LTdataOrder, LTdataMode));
+  _spi.beginTransaction(SPISettings(LTspeedMaximum, LTdataOrder, LTdataMode));
 #endif
 
   digitalWrite(_NSS, LOW);
-  SPI.transfer(Opcode);
-  SPI.transfer(0xFF);
+  _spi.transfer(Opcode);
+  _spi.transfer(0xFF);
 
   for ( i = 0; i < size; i++ )
   {
-    *(buffer + i) = SPI.transfer(0xFF);
+    *(buffer + i) = _spi.transfer(0xFF);
   }
   digitalWrite(_NSS, HIGH);
 
 
 #ifdef USE_SPI_TRANSACTION
-  SPI.endTransaction();
+  _spi.endTransaction();
 #endif
   //checkBusy();
 }
@@ -554,17 +560,17 @@ void SX128XLT::setMode(uint8_t modeconfig)
   checkBusy();
 
 #ifdef USE_SPI_TRANSACTION     //to use SPI_TRANSACTION enable define at beginning of CPP file 
-  SPI.beginTransaction(SPISettings(LTspeedMaximum, LTdataOrder, LTdataMode));
+  _spi.beginTransaction(SPISettings(LTspeedMaximum, LTdataOrder, LTdataMode));
 #endif
 
 
   digitalWrite(_NSS, LOW);
-  SPI.transfer(Opcode);
-  SPI.transfer(modeconfig);
+  _spi.transfer(Opcode);
+  _spi.transfer(modeconfig);
   digitalWrite(_NSS, HIGH);
 
 #ifdef USE_SPI_TRANSACTION
-  SPI.endTransaction();
+  _spi.endTransaction();
 #endif
 
   _OperatingMode = modeconfig;
@@ -1132,23 +1138,23 @@ uint8_t SX128XLT::transmit(uint8_t *txbuffer, uint8_t size, uint16_t timeout, in
   checkBusy();
 
 #ifdef USE_SPI_TRANSACTION     //to use SPI_TRANSACTION enable define at beginning of CPP file 
-  SPI.beginTransaction(SPISettings(LTspeedMaximum, LTdataOrder, LTdataMode));
+  _spi.beginTransaction(SPISettings(LTspeedMaximum, LTdataOrder, LTdataMode));
 #endif
 
   digitalWrite(_NSS, LOW);
-  SPI.transfer(RADIO_WRITE_BUFFER);
-  SPI.transfer(0);
+  _spi.transfer(RADIO_WRITE_BUFFER);
+  _spi.transfer(0);
 
   for (index = 0; index < size; index++)
   {
     bufferdata = txbuffer[index];
-    SPI.transfer(bufferdata);
+    _spi.transfer(bufferdata);
   }
 
   digitalWrite(_NSS, HIGH);
 
 #ifdef USE_SPI_TRANSACTION
-  SPI.endTransaction();
+  _spi.endTransaction();
 #endif
 
   _TXPacketL = size;
@@ -1435,24 +1441,24 @@ uint8_t SX128XLT::receive(uint8_t *rxbuffer, uint8_t size, uint16_t timeout, uin
   checkBusy();
   
 #ifdef USE_SPI_TRANSACTION           //to use SPI_TRANSACTION enable define at beginning of CPP file 
-  SPI.beginTransaction(SPISettings(LTspeedMaximum, LTdataOrder, LTdataMode));
+  _spi.beginTransaction(SPISettings(LTspeedMaximum, LTdataOrder, LTdataMode));
 #endif
 
   digitalWrite(_NSS, LOW);             //start the burst read
-  SPI.transfer(RADIO_READ_BUFFER);
-  SPI.transfer(RXstart);
-  SPI.transfer(0xFF);
+  _spi.transfer(RADIO_READ_BUFFER);
+  _spi.transfer(RXstart);
+  _spi.transfer(0xFF);
 
   for (index = RXstart; index < RXend; index++)
   {
-    regdata = SPI.transfer(0);
+    regdata = _spi.transfer(0);
     rxbuffer[index] = regdata;
   }
 
   digitalWrite(_NSS, HIGH);
 
 #ifdef USE_SPI_TRANSACTION
-  SPI.endTransaction();
+  _spi.endTransaction();
 #endif
 
   return _RXPacketL;                     //so we can check for packet having enough buffer space
@@ -1547,12 +1553,12 @@ void SX128XLT::startWriteSXBuffer(uint8_t ptr)
   checkBusy();
   
   #ifdef USE_SPI_TRANSACTION        //to use SPI_TRANSACTION enable define at beginning of CPP file 
-  SPI.beginTransaction(SPISettings(LTspeedMaximum, LTdataOrder, LTdataMode));
+  _spi.beginTransaction(SPISettings(LTspeedMaximum, LTdataOrder, LTdataMode));
 #endif
   
   digitalWrite(_NSS, LOW);
-  SPI.transfer(RADIO_WRITE_BUFFER);
-  SPI.transfer(ptr);                //address in SX buffer to write to     
+  _spi.transfer(RADIO_WRITE_BUFFER);
+  _spi.transfer(ptr);                //address in SX buffer to write to     
   //SPI interface ready for byte to write to buffer
 }
 
@@ -1566,7 +1572,7 @@ uint8_t  SX128XLT::endWriteSXBuffer()
   digitalWrite(_NSS, HIGH);
   
   #ifdef USE_SPI_TRANSACTION
-  SPI.endTransaction();
+  _spi.endTransaction();
 #endif
   
   return _TXPacketL;
@@ -1585,15 +1591,15 @@ void SX128XLT::startReadSXBuffer(uint8_t ptr)
   checkBusy();
   
   #ifdef USE_SPI_TRANSACTION             //to use SPI_TRANSACTION enable define at beginning of CPP file 
-  SPI.beginTransaction(SPISettings(LTspeedMaximum, LTdataOrder, LTdataMode));
+  _spi.beginTransaction(SPISettings(LTspeedMaximum, LTdataOrder, LTdataMode));
   #endif
 
   digitalWrite(_NSS, LOW);               //start the burst read
-  SPI.transfer(RADIO_READ_BUFFER);
-  SPI.transfer(ptr);
-  SPI.transfer(0xFF);
+  _spi.transfer(RADIO_READ_BUFFER);
+  _spi.transfer(ptr);
+  _spi.transfer(0xFF);
 
-  //next line would be data = SPI.transfer(0);
+  //next line would be data = _spi.transfer(0);
   //SPI interface ready for byte to read from
 }
 
@@ -1607,7 +1613,7 @@ uint8_t SX128XLT::endReadSXBuffer()
   digitalWrite(_NSS, HIGH);
   
   #ifdef USE_SPI_TRANSACTION
-  SPI.endTransaction();
+  _spi.endTransaction();
 #endif
   
   return _RXPacketL;
@@ -1620,7 +1626,7 @@ void SX128XLT::writeUint8(uint8_t x)
   Serial.println(F("writeUint8()"));
 #endif
 
-  SPI.transfer(x);
+  _spi.transfer(x);
 
   _TXPacketL++;                     //increment count of bytes written
 }
@@ -1632,7 +1638,7 @@ uint8_t SX128XLT::readUint8()
 #endif
   byte x;
 
-  x = SPI.transfer(0);
+  x = _spi.transfer(0);
 
   _RXPacketL++;                      //increment count of bytes read
   return (x);
@@ -1645,7 +1651,7 @@ void SX128XLT::writeInt8(int8_t x)
   Serial.println(F("writeInt8()"));
 #endif
 
-  SPI.transfer(x);
+  _spi.transfer(x);
 
   _TXPacketL++;                      //increment count of bytes written
 }
@@ -1658,7 +1664,7 @@ int8_t SX128XLT::readInt8()
 #endif
   int8_t x;
 
-  x = SPI.transfer(0);
+  x = _spi.transfer(0);
 
   _RXPacketL++;                      //increment count of bytes read
   return (x);
@@ -1671,8 +1677,8 @@ void SX128XLT::writeInt16(int16_t x)
   Serial.println(F("writeInt16()"));
 #endif
 
-  SPI.transfer(lowByte(x));
-  SPI.transfer(highByte(x));
+  _spi.transfer(lowByte(x));
+  _spi.transfer(highByte(x));
 
   _TXPacketL = _TXPacketL + 2;         //increment count of bytes written
 }
@@ -1685,8 +1691,8 @@ int16_t SX128XLT::readInt16()
 #endif
   byte lowbyte, highbyte;
 
-  lowbyte = SPI.transfer(0);
-  highbyte = SPI.transfer(0);
+  lowbyte = _spi.transfer(0);
+  highbyte = _spi.transfer(0);
 
   _RXPacketL = _RXPacketL + 2;         //increment count of bytes read
   return ((highbyte << 8) + lowbyte);
@@ -1699,8 +1705,8 @@ void SX128XLT::writeUint16(uint16_t x)
   Serial.println(F("writeUint16()"));
 #endif
 
-  SPI.transfer(lowByte(x));
-  SPI.transfer(highByte(x));
+  _spi.transfer(lowByte(x));
+  _spi.transfer(highByte(x));
 
   _TXPacketL = _TXPacketL + 2;         //increment count of bytes written
 }
@@ -1713,8 +1719,8 @@ uint16_t SX128XLT::readUint16()
 #endif
   byte lowbyte, highbyte;
 
-  lowbyte = SPI.transfer(0);
-  highbyte = SPI.transfer(0);
+  lowbyte = _spi.transfer(0);
+  highbyte = _spi.transfer(0);
 
   _RXPacketL = _RXPacketL + 2;         //increment count of bytes read
   return ((highbyte << 8) + lowbyte);
@@ -1739,7 +1745,7 @@ void SX128XLT::writeInt32(int32_t x)
   for (i = 0; i < 4; i++)
   {
     j = data.b[i];
-    SPI.transfer(j);
+    _spi.transfer(j);
   }
 
   _TXPacketL = _TXPacketL + 4;         //increment count of bytes written
@@ -1762,7 +1768,7 @@ int32_t SX128XLT::readInt32()
 
   for (i = 0; i < 4; i++)
   {
-    j = SPI.transfer(0);
+    j = _spi.transfer(0);
     readdata.b[i] = j;
   }
   _RXPacketL = _RXPacketL + 4;         //increment count of bytes read
@@ -1788,7 +1794,7 @@ void SX128XLT::writeUint32(uint32_t x)
   for (i = 0; i < 4; i++)
   {
     j = data.b[i];
-    SPI.transfer(j);
+    _spi.transfer(j);
   }
 
   _TXPacketL = _TXPacketL + 4;         //increment count of bytes written
@@ -1811,7 +1817,7 @@ uint32_t SX128XLT::readUint32()
 
   for (i = 0; i < 4; i++)
   {
-    j = SPI.transfer(0);
+    j = _spi.transfer(0);
     readdata.b[i] = j;
   }
   _RXPacketL = _RXPacketL + 4;         //increment count of bytes read
@@ -1837,7 +1843,7 @@ void SX128XLT::writeFloat(float x)
   for (i = 0; i < 4; i++)
   {
     j = data.b[i];
-    SPI.transfer(j);
+    _spi.transfer(j);
   }
 
   _TXPacketL = _TXPacketL + 4;         //increment count of bytes written
@@ -1860,7 +1866,7 @@ float SX128XLT::readFloat()
 
   for (i = 0; i < 4; i++)
   {
-    j = SPI.transfer(0);
+    j = _spi.transfer(0);
     readdata.b[i] = j;
   }
   _RXPacketL = _RXPacketL + 4;         //increment count of bytes read
@@ -1914,10 +1920,10 @@ void SX128XLT::writeBuffer(uint8_t *txbuffer, uint8_t size)
   for (index = 0; index < size; index++)
   {
     regdata = txbuffer[index];
-    SPI.transfer(regdata);
+    _spi.transfer(regdata);
   }
 
-  SPI.transfer(0);                     //this ensures last byte of buffer written really is a null (0)
+  _spi.transfer(0);                     //this ensures last byte of buffer written really is a null (0)
 
 }
 
@@ -1972,7 +1978,7 @@ uint8_t SX128XLT::readBuffer(uint8_t *rxbuffer)
 
   do                                     //need to find the size of the buffer first
   {
-    regdata = SPI.transfer(0);
+    regdata = _spi.transfer(0);
     rxbuffer[index] = regdata;           //fill the buffer.
     index++;
   } while (regdata != 0);                //keep reading until we have reached the null (0) at the buffer end
@@ -2264,23 +2270,23 @@ void SX128XLT::setSleep(uint8_t sleepconfig)
   checkBusy();
   
   #ifdef USE_SPI_TRANSACTION     //to use SPI_TRANSACTION enable define at beginning of CPP file 
-  SPI.beginTransaction(SPISettings(LTspeedMaximum, LTdataOrder, LTdataMode));
+  _spi.beginTransaction(SPISettings(LTspeedMaximum, LTdataOrder, LTdataMode));
 #endif
 
   //need to save registers to device RAM first
   digitalWrite(_NSS, LOW);
-  SPI.transfer(RADIO_SET_SAVECONTEXT);
+  _spi.transfer(RADIO_SET_SAVECONTEXT);
   digitalWrite(_NSS, HIGH);
   
   checkBusy();
   
   digitalWrite(_NSS, LOW);
-  SPI.transfer(RADIO_SET_SLEEP);
-  SPI.transfer(sleepconfig);
+  _spi.transfer(RADIO_SET_SLEEP);
+  _spi.transfer(sleepconfig);
   digitalWrite(_NSS, HIGH);
   
   #ifdef USE_SPI_TRANSACTION
-  SPI.endTransaction();
+  _spi.endTransaction();
 #endif
   delay(1);           //allow time for shutdown
 }
@@ -2331,18 +2337,18 @@ uint8_t SX128XLT::getByteSXBuffer(uint8_t addr)
   setMode(MODE_STDBY_RC);                     //this is needed to ensure we can read from buffer OK.
 
 #ifdef USE_SPI_TRANSACTION                    //to use SPI_TRANSACTION enable define at beginning of CPP file 
-  SPI.beginTransaction(SPISettings(LTspeedMaximum, LTdataOrder, LTdataMode));
+  _spi.beginTransaction(SPISettings(LTspeedMaximum, LTdataOrder, LTdataMode));
 #endif
 
   digitalWrite(_NSS, LOW);             //start the burst read
-  SPI.transfer(RADIO_READ_BUFFER);
-  SPI.transfer(addr);
-  SPI.transfer(0xFF);
-  regdata = SPI.transfer(0);
+  _spi.transfer(RADIO_READ_BUFFER);
+  _spi.transfer(addr);
+  _spi.transfer(0xFF);
+  regdata = _spi.transfer(0);
   digitalWrite(_NSS, HIGH);
 
 #ifdef USE_SPI_TRANSACTION
-  SPI.endTransaction();
+  _spi.endTransaction();
 #endif
 
   return regdata;
@@ -2360,17 +2366,17 @@ void SX128XLT::printSXBufferHEX(uint8_t start, uint8_t end)
   setMode(MODE_STDBY_RC);
 
 #ifdef USE_SPI_TRANSACTION     //to use SPI_TRANSACTION enable define at beginning of CPP file 
-  SPI.beginTransaction(SPISettings(LTspeedMaximum, LTdataOrder, LTdataMode));
+  _spi.beginTransaction(SPISettings(LTspeedMaximum, LTdataOrder, LTdataMode));
 #endif
 
   digitalWrite(_NSS, LOW);                       //start the burst read
-  SPI.transfer(RADIO_READ_BUFFER);
-  SPI.transfer(start);
-  SPI.transfer(0xFF);
+  _spi.transfer(RADIO_READ_BUFFER);
+  _spi.transfer(start);
+  _spi.transfer(0xFF);
 
   for (index = start; index <= end; index++)
   {
-    regdata = SPI.transfer(0);
+    regdata = _spi.transfer(0);
     printHEXByte(regdata);
     Serial.print(F(" "));
 
@@ -2378,7 +2384,7 @@ void SX128XLT::printSXBufferHEX(uint8_t start, uint8_t end)
   digitalWrite(_NSS, HIGH);
   
   #ifdef USE_SPI_TRANSACTION
-  SPI.endTransaction();
+  _spi.endTransaction();
 #endif
 
 }
@@ -2488,28 +2494,28 @@ uint8_t SX128XLT::transmitAddressed(uint8_t *txbuffer, uint8_t size, char txpack
   checkBusy();
 
 #ifdef USE_SPI_TRANSACTION     //to use SPI_TRANSACTION enable define at beginning of CPP file 
-  SPI.beginTransaction(SPISettings(LTspeedMaximum, LTdataOrder, LTdataMode));
+  _spi.beginTransaction(SPISettings(LTspeedMaximum, LTdataOrder, LTdataMode));
 #endif
 
   digitalWrite(_NSS, LOW);
-  SPI.transfer(RADIO_WRITE_BUFFER);
-  SPI.transfer(0);
+  _spi.transfer(RADIO_WRITE_BUFFER);
+  _spi.transfer(0);
   
-  SPI.transfer(txpackettype);                     //Write the packet type
-  SPI.transfer(txdestination);                    //Destination node
-  SPI.transfer(txsource);                         //Source node
+  _spi.transfer(txpackettype);                     //Write the packet type
+  _spi.transfer(txdestination);                    //Destination node
+  _spi.transfer(txsource);                         //Source node
   _TXPacketL = 3 + size;                          //we have added 3 header bytes to size
 
   for (index = 0; index < size; index++)
   {
     bufferdata = txbuffer[index];
-    SPI.transfer(bufferdata);
+    _spi.transfer(bufferdata);
   }
 
   digitalWrite(_NSS, HIGH);
 
 #ifdef USE_SPI_TRANSACTION
-  SPI.endTransaction();
+  _spi.endTransaction();
 #endif
 
   
@@ -2588,28 +2594,28 @@ uint8_t SX128XLT::receiveAddressed(uint8_t *rxbuffer, uint8_t size, uint16_t tim
   checkBusy();
   
 #ifdef USE_SPI_TRANSACTION           //to use SPI_TRANSACTION enable define at beginning of CPP file 
-  SPI.beginTransaction(SPISettings(LTspeedMaximum, LTdataOrder, LTdataMode));
+  _spi.beginTransaction(SPISettings(LTspeedMaximum, LTdataOrder, LTdataMode));
 #endif
 
   digitalWrite(_NSS, LOW);             //start the burst read
-  SPI.transfer(RADIO_READ_BUFFER);
-  SPI.transfer(RXstart);
-  SPI.transfer(0xFF);
+  _spi.transfer(RADIO_READ_BUFFER);
+  _spi.transfer(RXstart);
+  _spi.transfer(0xFF);
   
-  _RXPacketType = SPI.transfer(0);
-  _RXDestination = SPI.transfer(0);
-  _RXSource = SPI.transfer(0);
+  _RXPacketType = _spi.transfer(0);
+  _RXDestination = _spi.transfer(0);
+  _RXSource = _spi.transfer(0);
 
   for (index = RXstart; index < RXend; index++)
   {
-    regdata = SPI.transfer(0);
+    regdata = _spi.transfer(0);
     rxbuffer[index] = regdata;
   }
 
   digitalWrite(_NSS, HIGH);
 
 #ifdef USE_SPI_TRANSACTION
-  SPI.endTransaction();
+  _spi.endTransaction();
 #endif
 
   return _RXPacketL;                     //so we can check for packet having enough buffer space
@@ -2647,24 +2653,24 @@ uint8_t SX128XLT::readPacket(uint8_t *rxbuffer, uint8_t size)
   RXend = RXstart + _RXPacketL;
 
   #ifdef USE_SPI_TRANSACTION     //to use SPI_TRANSACTION enable define at beginning of CPP file 
-  SPI.beginTransaction(SPISettings(LTspeedMaximum, LTdataOrder, LTdataMode));
+  _spi.beginTransaction(SPISettings(LTspeedMaximum, LTdataOrder, LTdataMode));
 #endif
   
   digitalWrite(_NSS, LOW);               //start the burst read
-  SPI.transfer(RADIO_READ_BUFFER);
-  SPI.transfer(RXstart);
-  SPI.transfer(0xFF);
+  _spi.transfer(RADIO_READ_BUFFER);
+  _spi.transfer(RXstart);
+  _spi.transfer(0xFF);
 
   for (index = RXstart; index < RXend; index++)
   {
-    regdata = SPI.transfer(0);
+    regdata = _spi.transfer(0);
     rxbuffer[index] = regdata;
   }
 
   digitalWrite(_NSS, HIGH);
   
   #ifdef USE_SPI_TRANSACTION
-  SPI.endTransaction();
+  _spi.endTransaction();
 #endif
 
   return _RXPacketL;                     //so we can check for packet having enough buffer space
@@ -2702,10 +2708,10 @@ void SX128XLT::writeBufferChar(char *txbuffer, uint8_t size)
   for (index = 0; index < size; index++)
   {
     regdata = txbuffer[index];
-    SPI.transfer(regdata);
+    _spi.transfer(regdata);
   }
 
-  SPI.transfer(0);                     //this ensures last byte of buffer writen really is a null (0)
+  _spi.transfer(0);                     //this ensures last byte of buffer writen really is a null (0)
 
 }
 
@@ -2720,7 +2726,7 @@ uint8_t SX128XLT::readBufferChar(char *rxbuffer)
 
   do                                     //need to find the size of the buffer first
   {
-    regdata = SPI.transfer(0);
+    regdata = _spi.transfer(0);
     rxbuffer[index] = regdata;           //fill the buffer.
     index++;
   } while (regdata != 0);                //keep reading until we have reached the null (0) at the buffer end

--- a/src/SX128XLT.h
+++ b/src/SX128XLT.h
@@ -25,11 +25,15 @@
   
 **************************************************************************/
 
+class SPIClass; // forward declaration
+
 class SX128XLT  {
 
   public:
 
     SX128XLT();
+
+    void setSpi(SPIClass& spi);
 
     bool begin(int8_t pinNSS, int8_t pinNRESET, int8_t pinRFBUSY, int8_t pinDIO1, int8_t pinDIO2, int8_t pinDIO3, int8_t pinRXEN, int8_t pinTXEN, uint8_t device);
     bool begin(int8_t pinNSS, int8_t pinNRESET, int8_t pinRFBUSY, int8_t pinDIO1, uint8_t device);
@@ -193,5 +197,6 @@ class SX128XLT  {
     uint16_t savedCalibration;
     uint32_t savedFrequencyReg;
 
+    SPIClass& _spi; // device to be used for SPI communication
 };
 #endif


### PR DESCRIPTION
Some hardware have several SPI devs, for instance Teensy 3.x, 4.x.
Current implementation of LoRa library allows to use only first SPI dev, this fix add new method setSpi(SPIClass& spi) to allow different SPI dev to be used.
By default main spi dev is used (SPI), but it is possible to use other:

    LT.setSpi(SPI1);